### PR TITLE
Add Assertion throwsError assertion for exact error

### DIFF
--- a/Sources/SwiftyTestAssertions/AssertThrowsError+Equatable.swift
+++ b/Sources/SwiftyTestAssertions/AssertThrowsError+Equatable.swift
@@ -1,0 +1,39 @@
+import XCTest
+
+/// Asserts that an expression throws expected error.
+/// - parameter expression: Throwable expression.
+/// - parameter error: Expected `Equatable` error.
+/// - parameter file: The file where the assertion failed.
+/// - parameter line: The line on which the assertion failed.
+public func Assert<T, E: Error & Equatable>(
+    _ expression: @autoclosure (() throws -> T),
+    throwsError error: E,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+
+    XCTAssertThrowsError(
+        try expression(),
+        file: file,
+        line: line
+    ) { actualError in
+        guard let actualError = actualError as? E else {
+            XCTFail(
+                """
+                Threw wrong type of error \"(\"\(type(of: actualError))\")\" \
+                instead of expected type \"(\"\(type(of: error))\")\"
+                """,
+                file: file,
+                line: line
+            )
+            return
+        }
+
+        XCTAssertEqual(
+            error,
+            actualError,
+            file: file,
+            line: line
+        )
+    }
+}


### PR DESCRIPTION
In this PR:
- added `Assert(_:,throwsError:,file:,line:)` assertion that expects exact `Equatable` error to be thrown from an expression.