### PR TITLE
Add AssertAsync assertion for exact error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,13 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftyTestAssertions",
+    platforms: [
+        .iOS(.v14),
+        .macOS(.v12),
+        .watchOS(.v7),
+        .tvOS(.v15),
+        .visionOS(.v1),
+    ],
     products: [
         .library(
             name: "SwiftyTestAssertions",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ I've been using these assertions in different projects for a while and they prov
 1. Add `swifty-test-assertions` to package dependencies in `Package.swift`:
    
    ```swift
-   .package(url: "git@github.com:artem-y/swifty-test-assertions.git", from: "0.1.0"),
+   .package(url: "git@github.com:artem-y/swifty-test-assertions.git", from: "0.1.1"),
    ```
 2. Add `SwiftyTestAssertions` product dependency to test target(s) in `Package.swift`:
    ```swift

--- a/Sources/SwiftyTestAssertions/AssertThrowsError+Equatable.swift
+++ b/Sources/SwiftyTestAssertions/AssertThrowsError+Equatable.swift
@@ -80,7 +80,7 @@ public func AssertAsync<T, E: Error & Equatable>(
 
 fileprivate func makeWrongErrorTypeMessage(actualError: Error, expectedError: Error) -> String {
     """
-    Threw wrong type of error \"(\"\(type(of: actualError))\")\" \
-    instead of expected type \"(\"\(type(of: expectedError))\")\"
+    Threw wrong type of error ("\(type(of: actualError))") \
+    instead of expected type ("\(type(of: expectedError))")
     """
 }

--- a/Sources/SwiftyTestAssertions/AssertThrowsError+Equatable.swift
+++ b/Sources/SwiftyTestAssertions/AssertThrowsError+Equatable.swift
@@ -19,10 +19,10 @@ public func Assert<T, E: Error & Equatable>(
     ) { actualError in
         guard let actualError = actualError as? E else {
             XCTFail(
-                """
-                Threw wrong type of error \"(\"\(type(of: actualError))\")\" \
-                instead of expected type \"(\"\(type(of: error))\")\"
-                """,
+                makeWrongErrorTypeMessage(
+                    actualError: actualError,
+                    expectedError: error
+                ),
                 file: file,
                 line: line
             )
@@ -36,4 +36,51 @@ public func Assert<T, E: Error & Equatable>(
             line: line
         )
     }
+}
+
+/// Asserts that an async expression throws expected error.
+/// - parameter expression: Async throwable expression.
+/// - parameter error: Expected `Equatable` error.
+/// - parameter file: The file where the assertion failed.
+/// - parameter line: The line on which the assertion failed.
+public func AssertAsync<T, E: Error & Equatable>(
+    _ expression: @autoclosure (() async throws -> T),
+    throwsError error: E,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    do {
+        _ = try await expression()
+        XCTFail(
+            "AssertAsync..throwsError failed: didn't throw an error",
+            file: file,
+            line: line
+        )
+    } catch (let actualError) {
+        guard let actualError = actualError as? E else {
+            XCTFail(
+                makeWrongErrorTypeMessage(
+                    actualError: actualError,
+                    expectedError: error
+                ),
+                file: file,
+                line: line
+            )
+            return
+        }
+
+        XCTAssertEqual(
+            error,
+            actualError,
+            file: file,
+            line: line
+        )
+    }
+}
+
+fileprivate func makeWrongErrorTypeMessage(actualError: Error, expectedError: Error) -> String {
+    """
+    Threw wrong type of error \"(\"\(type(of: actualError))\")\" \
+    instead of expected type \"(\"\(type(of: expectedError))\")\"
+    """
 }


### PR DESCRIPTION
In this PR:
- added an async version of `Assert...throwsError` to check for exact errors from async functions
- specified platforms in `Package.swift` to enable the use of Swift concurrency
- updated recommended version to `0.1.1` in README
- removed redundant escaping characters from type mismatch error message